### PR TITLE
Sp query fix

### DIFF
--- a/lib/AppStateModel.js
+++ b/lib/AppStateModel.js
@@ -50,11 +50,11 @@ class AppStateModel extends BaseModel {
 
   /**
    * @method setLocation
-   * @description manually set the url location.  This should be used instead of 
+   * @description manually set the url location.  This should be used instead of
    * window.location.href = '/foo'.  This method passes location to the global
    * app-route element which handles updating the window.history state and fires
    * the AppStateStore state-update event.
-   * 
+   *
    * @param {String} location new url location
    */
   setLocation(location) {
@@ -88,11 +88,14 @@ class AppStateModel extends BaseModel {
   }
 
   _setLocationObject(fullpath) {
+    let query = queryString.parse(window.location.search);
+    query = Object.keys(query).length ? query : {};
+
     this.location = {
       fullpath : fullpath || this._getFullPath(),
       pathname : window.location.pathname.replace(/^\/+/, '/'),
       path : window.location.pathname.replace(/(^\/+|\/+$)/g, '').split('/'),
-      query : queryString.parse(window.location.search),
+      query,
       hash : window.location.hash.replace(/^#/, '')
     };
     return location;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucd-lib/cork-app-state",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Base AppStateModel class",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Ran into a compatibility issue between the `query-string` package and the `fast-deep-equal` package used in cork-app-utils. The query object did not have a `valueOf` method, which caused an error when going from a blank query object to one with properties. 

https://github.com/epoberezkin/fast-deep-equal/issues/49